### PR TITLE
Adding information when cy.audit is running without explicit thresholds

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1,3 +1,11 @@
+const defaultThresholds = {
+  performance: 100,
+  accessibility: 100,
+  "best-practices": 100,
+  seo: 100,
+  pwa: 100
+};
+
 Cypress.Commands.add("audit", (thresholds, opts, config) => {
   if (Cypress.browser.displayName !== "Chrome") {
     return cy.log("cypress-audit", "Not a chrome browser, skipping for now");
@@ -7,14 +15,15 @@ Cypress.Commands.add("audit", (thresholds, opts, config) => {
     const configThresholds = Cypress.config("lighthouse");
 
     if (!thresholds && !configThresholds) {
-      throw new Error(
-        "cypress-audit: It looks like you're missing the threshold config!"
+      cy.log(
+        "cypress-audit",
+        "It looks like you have not set thresholds yet. The test will be based on the 100 score for every metrics. Refer to https://github.com/mfrachet/cypress-audit to have more information and set thresholds by yourself :)."
       );
     }
 
     cy.task("audit", {
       url,
-      thresholds: thresholds || configThresholds,
+      thresholds: thresholds || configThresholds || defaultThresholds,
       opts,
       config
     }).then(errors => {

--- a/example/cypress.json
+++ b/example/cypress.json
@@ -1,9 +1,1 @@
-{
-  "lighthouse": {
-    "performance": 85,
-    "accessibility": 100,
-    "best-practices": 85,
-    "seo": 85,
-    "pwa": 50
-  }
-}
+{}

--- a/example/cypress/integration/examples/homepage.spec.js
+++ b/example/cypress/integration/examples/homepage.spec.js
@@ -2,7 +2,7 @@
 
 context("Homepage", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5000");
+    cy.visit("http://localhost:3000");
   });
 
   it("should verify lighthouse scores", () => {


### PR DESCRIPTION
This fixes: https://github.com/mfrachet/cypress-audit/issues/2

We can now use `cy.audit()` without thresholds set as argument or in cypress.json. In that case, a log is displayed in the console to inform the user + it launch a test using the default `100` score for every metrics:

<img width="1440" alt="Screenshot 2020-02-20 at 11 48 19" src="https://user-images.githubusercontent.com/3874873/74926993-1eeacd80-53d7-11ea-98d7-97f622690230.png">
