### PR TITLE
Adding scores when tests are passing

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -17,14 +17,16 @@ Cypress.Commands.add("audit", (thresholds, opts, config) => {
       thresholds: thresholds || configThresholds,
       opts,
       config
-    }).then(errors => {
-      if (errors.length > 0) {
-        throw new Error(
-          `cypress-audit: thresholds crossed.\n\n${errors.join("\n")}`
-        );
-      }
+    }).then(({ errors, results }) => {
+      const resultStr = `\n${results.join("\n")}`;
 
-      cy.log("cypress-audit", "Everything is good");
+      cy.log("cypress-audit", resultStr).then(() => {
+        if (errors.length > 0) {
+          throw new Error(
+            `cypress-audit: thresholds crossed.\n\n${errors.join("\n")}`
+          );
+        }
+      });
     });
   });
 });

--- a/example/cypress/integration/examples/homepage.spec.js
+++ b/example/cypress/integration/examples/homepage.spec.js
@@ -2,7 +2,7 @@
 
 context("Homepage", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5000");
+    cy.visit("http://localhost:3000");
   });
 
   it("should verify lighthouse scores", () => {

--- a/index.js
+++ b/index.js
@@ -4,16 +4,21 @@ let port;
 
 const compare = thresholds => newValue => {
   const errors = [];
+  const results = [];
 
   Object.keys(thresholds).forEach(key => {
     if (thresholds[key] > newValue[key]) {
       errors.push(
         `${key}: ${newValue[key]} is under ${thresholds[key]} threshold`
       );
+    } else {
+      results.push(
+        `${key}: ${newValue[key]} is >= ${thresholds[key]} threshold`
+      );
     }
   });
 
-  return errors;
+  return { errors, results };
 };
 
 const audit = ({ url, thresholds, opts = {}, config }) => {


### PR DESCRIPTION
This should fix https://github.com/mfrachet/cypress-audit/issues/3

- It displays the different scores when tests are successful
- It displays the different scores when tests are successful + isolate the failing one in an error:

<img width="1440" alt="Screenshot 2020-02-20 at 13 24 45" src="https://user-images.githubusercontent.com/3874873/74933580-9a06b080-53e4-11ea-9e47-2ab4c81b0027.png">
