### PR TITLE
Fix typo in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ module.exports = (on, config) => {
   on("task", {
     lighthouse: lighthouse(lighthouseReport => {
       console.log(lighthouseReport) // raw lighthouse report
-    },
+    }),
     pa11y: pa11y(pa11yReport => {
       console.log(pa11yReport) // raw pa11y report
     }),


### PR DESCRIPTION
The example for accessing the raw reports was missing a closing parenthesis.