### PR TITLE
Add option to generate a report for an a11y audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ it("should pass the audits", function () {
 ![A Pa11y record showing some test failing on color contrast, landmark, heading and regions.](./docs/pally.png)
 
 You can call `cy.pa11Y(opts)` with `opts` being any kind of [the pa11y options](https://github.com/pa11y/pa11y#configuration).
+`opts` additionally support a `report` property in which you can specify a `path` to save the a11y audit:
+
+```js
+cy.pa11y({
+  report: {
+    path: 'some/path/pa11y.json'
+  }
+})
+```
 
 ### cy.lighthouse()
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/audit/a11y-report
 
 # production
 /build

--- a/example/audit/cypress/integration/examples/homepage.spec.js
+++ b/example/audit/cypress/integration/examples/homepage.spec.js
@@ -16,6 +16,15 @@ context("The App", () => {
     cy.pa11y();
   });
 
+  it("generates an a11y report for the home page", () => {
+    cy.pa11y({
+      report: {
+        path: '../a11y-report/homepage.json'
+      },
+      errorThreshold: 20
+    });
+  });
+
   it("audits the authenticated page", () => {
     cy.login();
 

--- a/example/audit/cypress/integration/examples/homepage.spec.js
+++ b/example/audit/cypress/integration/examples/homepage.spec.js
@@ -21,7 +21,7 @@ context("The App", () => {
       report: {
         path: '../a11y-report/homepage.json'
       },
-      errorThreshold: 20
+      threshold: 20
     });
   });
 

--- a/example/audit/cypress/integration/examples/homepage.spec.js
+++ b/example/audit/cypress/integration/examples/homepage.spec.js
@@ -19,9 +19,8 @@ context("The App", () => {
   it("generates an a11y report for the home page", () => {
     cy.pa11y({
       report: {
-        path: '../a11y-report/homepage.json'
+        path: 'a11y-report/homepage.json'
       },
-      threshold: 20
     });
   });
 

--- a/src/a11y/commands.js
+++ b/src/a11y/commands.js
@@ -55,17 +55,19 @@ Cypress.Commands.add("pa11y", (opts) => {
 
   cy.url()
     .then((url) => cy.task("pa11y", { url, opts }))
-    .then((issues) => {
-      if (issues.length > ERROR_NUMBER_THRESHOLD) {
-        const groupedIssues = groupIssues(issues);
+    .then((results) => {
+      const { errorThreshold = ERROR_NUMBER_THRESHOLD } = opts;
+      const { issues = [] } = results;
+      const groupedIssues = groupIssues(issues);
 
-        const title =
-          issues.length === 1
-            ? `cy.pa11y - ${issues.length} accessibility violation was found`
-            : `cy.pa11y - ${issues.length} accessibility violations were found`;
+      const title =
+        issues.length === 1
+          ? `cy.pa11y - ${issues.length} accessibility violation was found`
+          : `cy.pa11y - ${issues.length} accessibility violations were found`;
+      
+      const formattedIssues = formatIssues(groupedIssues);
 
-        const formattedIssues = formatIssues(groupedIssues);
-
+      if (issues.length > errorThreshold) {
         throw new Error(`${title}\n\n${formattedIssues}`);
       }
     });

--- a/src/a11y/commands.js
+++ b/src/a11y/commands.js
@@ -56,7 +56,6 @@ Cypress.Commands.add("pa11y", (opts) => {
   cy.url()
     .then((url) => cy.task("pa11y", { url, opts }))
     .then((results) => {
-      const { threshold = ERROR_NUMBER_THRESHOLD } = opts;
       const { issues = [] } = results;
       const groupedIssues = groupIssues(issues);
 
@@ -67,8 +66,6 @@ Cypress.Commands.add("pa11y", (opts) => {
       
       const formattedIssues = formatIssues(groupedIssues);
 
-      if (issues.length > threshold) {
-        throw new Error(`${title}\n\n${formattedIssues}`);
-      }
+      throw new Error(`${title}\n\n${formattedIssues}`);
     });
 });

--- a/src/a11y/commands.js
+++ b/src/a11y/commands.js
@@ -56,7 +56,7 @@ Cypress.Commands.add("pa11y", (opts) => {
   cy.url()
     .then((url) => cy.task("pa11y", { url, opts }))
     .then((results) => {
-      const { errorThreshold = ERROR_NUMBER_THRESHOLD } = opts;
+      const { threshold = ERROR_NUMBER_THRESHOLD } = opts;
       const { issues = [] } = results;
       const groupedIssues = groupIssues(issues);
 
@@ -67,7 +67,7 @@ Cypress.Commands.add("pa11y", (opts) => {
       
       const formattedIssues = formatIssues(groupedIssues);
 
-      if (issues.length > errorThreshold) {
+      if (issues.length > threshold) {
         throw new Error(`${title}\n\n${formattedIssues}`);
       }
     });

--- a/src/a11y/report.js
+++ b/src/a11y/report.js
@@ -2,13 +2,14 @@ const fs = require('fs');
 const path = require('path');
 
 /**
+ * Computes a default path for pa11y reports from the audited page URL.
  * Removes the protocol and replaces all occurences of `/` and `:` with `-`.
  * 
  * @param {string} pageUrl the url to normalize
  * @returns {string} the normalized url
  */
-const normalizePageUrl = (pageUrl = '') => (
-    `${pageUrl
+const computeDefaultReportPath = (pageUrl = '') => (
+    `a11y-report/${pageUrl
         // remove protocol
         .replace(/http(s)?:\/\//, '')
         // replace / and : with -
@@ -16,14 +17,6 @@ const normalizePageUrl = (pageUrl = '') => (
         // remove final - if url had trailing slash
         .replace(/-$/, '')}.json`
 );
-
-/**
- * Computes a default path for pa11y reports from the audited page URL.
- * 
- * @param {string} pageUrl the audited page URL
- * @returns a path to save the report
- */
-const computeDefaultReportPath = (pageUrl = '') => `a11y-report/${normalizePageUrl(pageUrl)}`; 
 
 /**
  * Writes a pa11y report to <report.basePath>/<report.fileName>

--- a/src/a11y/report.js
+++ b/src/a11y/report.js
@@ -4,7 +4,7 @@ const path = require('path');
 /**
  * Removes the protocol and replaces all occurences of `/` and `:` with `-`.
  * 
- * @param {*} pageUrl the url to normalize
+ * @param {string} pageUrl the url to normalize
  * @returns {string} the normalized url
  */
 const normalizePageUrl = (pageUrl = '') => (
@@ -20,7 +20,7 @@ const normalizePageUrl = (pageUrl = '') => (
 /**
  * Computes a default path for pa11y reports from the audited page URL.
  * 
- * @param {*} pageUrl the audited page URL
+ * @param {string} pageUrl the audited page URL
  * @returns a path to save the report
  */
 const computeDefaultReportPath = (pageUrl = '') => `a11y-report/${normalizePageUrl(pageUrl)}`; 
@@ -31,7 +31,7 @@ const computeDefaultReportPath = (pageUrl = '') => `a11y-report/${normalizePageU
  * page URL.
  * 
  * @param {*} report the pa11y report
- * @param {*} opts 
+ * @param {{ path: string }} opts 
  */
 const writePa11yReportToFile = (report, opts) => {
     const { reportPath = computeDefaultReportPath(report.pageUrl) } = opts;

--- a/src/a11y/report.js
+++ b/src/a11y/report.js
@@ -27,7 +27,7 @@ const computeDefaultReportPath = (pageUrl = '') => (
  * @param {{ path: string }} opts 
  */
 const writePa11yReportToFile = (report, opts) => {
-    const { reportPath = computeDefaultReportPath(report.pageUrl) } = opts;
+    const { path: reportPath = computeDefaultReportPath(report.pageUrl) } = opts;
     const absoluteReportPath = path.resolve(process.cwd(), reportPath);
     const reportDir = path.dirname(absoluteReportPath);
     fs.mkdirSync(reportDir, { recursive: true });

--- a/src/a11y/report.js
+++ b/src/a11y/report.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Removes the protocol and replaces all occurences of `/` and `:` with `-`.
+ * 
+ * @param {*} pageUrl the url to normalize
+ * @returns {string} the normalized url
+ */
+const normalizePageUrl = (pageUrl = '') => (
+    `${pageUrl
+        // remove protocol
+        .replace(/http(s)?:\/\//, '')
+        // replace / and : with -
+        .replace(/(\/|:)/g, '-')
+        // remove final - if url had trailing slash
+        .replace(/-$/, '')}.json`
+);
+
+/**
+ * Computes a default path for pa11y reports from the audited page URL.
+ * 
+ * @param {*} pageUrl the audited page URL
+ * @returns a path to save the report
+ */
+const computeDefaultReportPath = (pageUrl = '') => `a11y-report/${normalizePageUrl(pageUrl)}`; 
+
+/**
+ * Writes a pa11y report to <report.basePath>/<report.fileName>
+ * If <report.fileName> is not defined, it will generate one by normalizing the report
+ * page URL.
+ * 
+ * @param {*} report the pa11y report
+ * @param {*} opts 
+ */
+const writePa11yReportToFile = (report, opts) => {
+    const { reportPath = computeDefaultReportPath(report.pageUrl) } = opts;
+    const absoluteReportPath = path.resolve(process.cwd(), reportPath);
+    const reportDir = path.dirname(absoluteReportPath);
+    fs.mkdirSync(reportDir, { recursive: true });
+    fs.writeFileSync(absoluteReportPath, JSON.stringify(report));
+};
+
+module.exports = { writePa11yReportToFile };

--- a/src/a11y/task.js
+++ b/src/a11y/task.js
@@ -11,15 +11,18 @@ const pa11y = (callback) => ({ url, opts }) => {
     .then((browser) =>
       pa11yLib(url, { browser, runners: ["axe"], ...pa11yOpts }).then((results) => {
 
+        const a11yauditPassed = (pa11yOpts.errorThreshold || 0) >= results.issues.length;
+        const report = { passed: a11yauditPassed, ...results };
+
         if(reportOpts) {
-          writePa11yReportToFile(results, reportOpts);
+          writePa11yReportToFile(report, reportOpts);
         }
 
         if (callback) {
-          callback(results);
+          callback(report);
         }
 
-        return results;
+        return report;
       })
     );
 };

--- a/src/a11y/task.js
+++ b/src/a11y/task.js
@@ -11,7 +11,7 @@ const pa11y = (callback) => ({ url, opts }) => {
     .then((browser) =>
       pa11yLib(url, { browser, runners: ["axe"], ...pa11yOpts }).then((results) => {
 
-        const a11yauditPassed = (pa11yOpts.errorThreshold || 0) >= results.issues.length;
+        const a11yauditPassed = (pa11yOpts.threshold || 0) >= results.issues.length;
         const report = { passed: a11yauditPassed, ...results };
 
         if(reportOpts) {

--- a/src/a11y/task.js
+++ b/src/a11y/task.js
@@ -1,18 +1,25 @@
 const pa11yLib = require("pa11y");
 const puppeteer = require("puppeteer");
+const { writePa11yReportToFile } = require('./report');
 
 const pa11y = (callback) => ({ url, opts }) => {
+  const { report: reportOpts, ...pa11yOpts } = opts;
   return puppeteer
     .connect({
       browserURL: `http://localhost:${global.port}`,
     })
     .then((browser) =>
-      pa11yLib(url, { browser, runners: ["axe"], ...opts }).then((results) => {
+      pa11yLib(url, { browser, runners: ["axe"], ...pa11yOpts }).then((results) => {
+
+        if(reportOpts) {
+          writePa11yReportToFile(results, reportOpts);
+        }
+
         if (callback) {
           callback(results);
         }
 
-        return results.issues || [];
+        return results;
       })
     );
 };

--- a/src/a11y/task.js
+++ b/src/a11y/task.js
@@ -2,7 +2,7 @@ const pa11yLib = require("pa11y");
 const puppeteer = require("puppeteer");
 const { writePa11yReportToFile } = require('./report');
 
-const pa11y = (callback) => ({ url, opts }) => {
+const pa11y = (callback) => ({ url, opts = {} }) => {
   const { report: reportOpts, ...pa11yOpts } = opts;
   return puppeteer
     .connect({
@@ -10,19 +10,15 @@ const pa11y = (callback) => ({ url, opts }) => {
     })
     .then((browser) =>
       pa11yLib(url, { browser, runners: ["axe"], ...pa11yOpts }).then((results) => {
-
-        const a11yauditPassed = (pa11yOpts.threshold || 0) >= results.issues.length;
-        const report = { passed: a11yauditPassed, ...results };
-
         if(reportOpts) {
-          writePa11yReportToFile(report, reportOpts);
+          writePa11yReportToFile(results, reportOpts);
         }
 
         if (callback) {
-          callback(report);
+          callback(results);
         }
 
-        return report;
+        return results;
       })
     );
 };


### PR DESCRIPTION
This PR implements an option to save the results of a `pa11y` audit to a JSON file.

This can be useful to upload the generated audits as artifacts to CI systems; for example, I am using this to publish the a11y audit results in GitLab's a11y widget for merge requests.

Additionally, this PR adds support for the `threshold` option of `pa11y` configuration: the `pa11y` task will not throw an option if the number of issues is below the provided threshold.