### PR TITLE
Respect Pa11y threshold

### DIFF
--- a/packages/pa11y/src/__tests__/command-handler.spec.js
+++ b/packages/pa11y/src/__tests__/command-handler.spec.js
@@ -199,5 +199,33 @@ describe("pa11y command", () => {
         `);
       }
     });
+
+    it("uses cy.log when threshold is above number of errors", async () => {
+      global.Cypress = {
+        browser: {
+          displayName: "Chrome",
+        },
+      };
+
+      global.cy = {
+        url: () => Promise.resolve("my-url"),
+        task: jest.fn(() =>
+          Promise.resolve([
+            {
+              code: "first",
+              message: "Something wrong occured",
+              context: "Additional context found",
+            }
+          ])
+        ),
+        log: jest.fn(),
+      };
+
+      let consoleSpy = jest.spyOn(cy, 'log').mockImplementation()
+      await pa11yCommandHandler({ threshold: 2 })
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
+      // TODO: Fix expected message string
+      // expect(consoleSpy).toHaveBeenCalledWith('cy.pa11y - 1 accessibility violation was found\n\nIssue: first, # of occurrences: 1.\n  - Something wrong occured\n  - Context: Additional context found          \n\n');
+    })
   });
 });

--- a/packages/pa11y/src/command-handler.js
+++ b/packages/pa11y/src/command-handler.js
@@ -78,7 +78,11 @@ const pa11yCommandHandler = (opts) => {
 
         const formattedIssues = formatIssues(groupedIssues);
 
-        throw new Error(`${title}\n\n${formattedIssues}`);
+        if(opts && opts.threshold && issues.length < opts.threshold) {
+          cy.log(`${title}\n\n${formattedIssues}`);
+        } else {
+          throw new Error(`${title}\n\n${formattedIssues}`);
+        }
       }
     });
 };


### PR DESCRIPTION
### Description

- Uses `cy.log` instead of throwing error when pa11y opts threshold is above that of returned issues.
- Added tests for new implementation - could use help asserting on the exact message.
- Fixes: [#98](https://github.com/mfrachet/cypress-audit/issues/98).

### Tests Passing
```
 PASS  src/__tests__/command-handler.spec.js
  pa11y command
    verify browser compat
      ✓ resolves with no errors when the browser is Chrome (3 ms)
      ✓ resolves with no errors when the browser is Chromium
      ✓ resolves with no errors when the browser is Canary
      ✓ shows an error when the browser is Edge (1 ms)
    when issues
      ✓ shows an error when there s one error (2 ms)
      ✓ shows multiple errors when there are multiple errors
      ✓ shows multiple errors when there are multiple errors without selector (1 ms)
      ✓ uses cy.log when threshold is above number of errors
```