### PR TITLE
Options, Thresholds and Config in cypress.json

### DIFF
--- a/examples/cra-authenticated/cypress.json
+++ b/examples/cra-authenticated/cypress.json
@@ -1,4 +1,16 @@
 {
   "baseUrl": "http://localhost:3000",
-  "video": false
+  "video": false,
+  "lighthouse": {
+    "options": {
+      "formFactor": "desktop",
+      "screenEmulation": {
+        "width": 500,
+        "height": 940,
+        "deviceScaleRatio": 1,
+        "mobile": false,
+        "disable": false
+      }
+    }
+  }
 }

--- a/examples/cra-authenticated/cypress/integration/examples/homepage.spec.js
+++ b/examples/cra-authenticated/cypress/integration/examples/homepage.spec.js
@@ -22,7 +22,7 @@ context("The App", () => {
 
     cy.lighthouse({
       performance: 50,
-      "first-contentful-paint": 3000,
+      "first-contentful-paint": 3500,
       accessibility: 50,
       "best-practices": 50,
       seo: 50,

--- a/examples/cra-authenticated/package-lock.json
+++ b/examples/cra-authenticated/package-lock.json
@@ -31,7 +31,7 @@
       "license": "MIT",
       "dependencies": {
         "@cypress-audit/shared": "^1.1.0",
-        "lighthouse": "^8.5.1"
+        "lighthouse": "^8.6.0"
       }
     },
     "../../packages/lighthouse/node_modules/@cypress-audit/shared": {
@@ -22634,7 +22634,7 @@
       "version": "file:../../packages/lighthouse",
       "requires": {
         "@cypress-audit/shared": "^1.1.0",
-        "lighthouse": "^8.5.1"
+        "lighthouse": "^8.6.0"
       },
       "dependencies": {
         "@cypress-audit/shared": {

--- a/packages/lighthouse/README.md
+++ b/packages/lighthouse/README.md
@@ -105,11 +105,13 @@ While I would recommend to make per-test assumptions, it's possible to define ge
 ```json
 {
   "lighthouse": {
-    "performance": 85,
-    "accessibility": 50,
-    "best-practices": 85,
-    "seo": 85,
-    "pwa": 50
+    "thresholds": {
+      "performance": 85,
+      "accessibility": 50,
+      "best-practices": 85,
+      "seo": 85,
+      "pwa": 50
+    }
   }
 }
 ```
@@ -135,6 +137,25 @@ const lighthouseConfig = {
 
 cy.lighthouse(thresholds, lighthouseOptions, lighthouseConfig);
 ```
+
+## Globally set options and configs
+
+You can set default `lighthouseOptions` and `lighthouseConfig` to your `cypress.json` file using:
+
+```json
+{
+  "lighthouse": {
+    "options": {
+      /* put your options here, like formFactor by default */
+    },
+    "config": {
+      /* put your config here */
+    }
+  }
+}
+```
+
+These values can be override at the test level.
 
 ### Available metrics
 

--- a/packages/lighthouse/src/command-handler.js
+++ b/packages/lighthouse/src/command-handler.js
@@ -21,12 +21,18 @@ const lighthouseCommandHandler = (thresholds, opts, config) => {
   }
 
   return cy.url().then((url) => {
+    // Handling the default value in cypress.json for "thresholds", "config" and "options"
     const lighthouseConfig = Cypress.config("lighthouse");
+
     const configThresholds = lighthouseConfig
       ? lighthouseConfig.thresholds
       : undefined;
 
-    const deviceConfig = lighthouseConfig ? lighthouseConfig.config : undefined;
+    const globalOptions = lighthouseConfig
+      ? lighthouseConfig.options
+      : undefined;
+
+    const globalConfig = lighthouseConfig ? lighthouseConfig.config : undefined;
 
     if (!thresholds && !configThresholds) {
       cy.log(
@@ -40,8 +46,8 @@ const lighthouseCommandHandler = (thresholds, opts, config) => {
       .task("lighthouse", {
         url,
         thresholds: thresholds || configThresholds || defaultThresholds,
-        opts,
-        config: config || deviceConfig,
+        opts: opts || globalOptions,
+        config: config || globalConfig,
       })
       .then(({ errors, results }) => {
         results.forEach((res) => {

--- a/packages/lighthouse/src/command-handler.js
+++ b/packages/lighthouse/src/command-handler.js
@@ -21,7 +21,12 @@ const lighthouseCommandHandler = (thresholds, opts, config) => {
   }
 
   return cy.url().then((url) => {
-    const configThresholds = Cypress.config("lighthouse");
+    const lighthouseConfig = Cypress.config("lighthouse");
+    const configThresholds = lighthouseConfig
+      ? lighthouseConfig.thresholds
+      : undefined;
+
+    const deviceConfig = lighthouseConfig ? lighthouseConfig.config : undefined;
 
     if (!thresholds && !configThresholds) {
       cy.log(
@@ -36,7 +41,7 @@ const lighthouseCommandHandler = (thresholds, opts, config) => {
         url,
         thresholds: thresholds || configThresholds || defaultThresholds,
         opts,
-        config,
+        config: config || deviceConfig,
       })
       .then(({ errors, results }) => {
         results.forEach((res) => {


### PR DESCRIPTION
Fixes https://github.com/mfrachet/cypress-audit/issues/124

This PR introduces the Options, Thresholds and Config keys in cypress.json under the lighthouse section.

For instance, with this PR, it's possible to do:

```json
{
 "lighthouse": {
    "thresholds": {
      "performance": 1000
    },
    "options": {
      "formFactor": "desktop",
      "screenEmulation": {
        "width": 500,
        "height": 940,
        "deviceScaleRatio": 1,
        "mobile": false,
        "disable": false
      }
    }
  }
}
```

All these values can be overridden by tests.

⚠️ This introduces a breaking change because of the introduction of a sublevel in the configuration. Instead of putting the thresholds directly under the "lighthouse" key, you will have to put them in "lighthouse.thresholds