### PR TITLE
Use correct structure for lighthouseConfig for HTML output in documentation

### DIFF
--- a/packages/documentation/docs/guides/lighthouse/reports.md
+++ b/packages/documentation/docs/guides/lighthouse/reports.md
@@ -38,8 +38,9 @@ const lighthouseOptions = {
 };
 
 const lighthouseConfig = {
-  output: "html", //If output is not specified, then the json report will be generated
-  /* ... your lighthouse configs */
+  settings: { output: "html" },
+  extends: "lighthouse:default",
+  /* ... Alternatively, you could set your own lighthouse config */
 };
 
 cy.lighthouse(thresholds, lighthouseOptions, lighthouseConfig);


### PR DESCRIPTION
The current docs do not align to the necessary shape for HTML output.

This change also suggests how a user can easily inherit the default config while also adding HTML output.